### PR TITLE
Fix defaults and add helper tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 
 .DS_Store
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
 ## Usage
 
 ### Configuring Instances
-1. Click the extension icon in Chrome and go to "Options."
+1. Click the extension icon in Chrome and open the Settings page.
 2. Add your AEM instances:
    - Provide the name, author URL, and publish URL.
    - Include port numbers if necessary (e.g., 4502 for author, 4503 for publish).

--- a/content.js
+++ b/content.js
@@ -50,13 +50,16 @@ function getWcmModeFromUrl(url) {
     return urlObj.searchParams.get('wcmmode');
 }
 
-chrome.storage.sync.get([
-    'instances', 
-    'openNewTab', 
-    'enableAuthorButton', 
-    'enableViewAsPublishedButton', 
-    'enablePublishButton',
-    'enableEditButton'
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { getHostAndPort, urlsMatch, getWcmModeFromUrl };
+} else {
+    chrome.storage.sync.get([
+        'instances',
+        'openNewTab',
+        'enableAuthorButton',
+        'enableViewAsPublishedButton',
+        'enablePublishButton',
+        'enableEditButton'
 ], (data) => {
     const instances = data.instances || [];
     const openNewTab = data.openNewTab || false;
@@ -202,3 +205,4 @@ chrome.storage.sync.get([
         addButtons();
     }
 });
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "aem-toolkit",
+  "version": "1.0.0",
+  "description": "**AEM Toolkit** is a Chrome extension designed to streamline your Adobe Experience Manager (AEM) development and content management tasks. It simplifies navigation between author and publish instances, enhances your workflow with in-page controls, and provides quick access to essential AEM tools like OSGi bundles and CRXDE.",
+  "main": "background.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^30.0.0"
+  }
+}

--- a/settings.js
+++ b/settings.js
@@ -177,6 +177,9 @@ document.addEventListener('DOMContentLoaded', function () {
     function addUrlEntry(container, urlVal, portVal, isDefault = false) {
         const div = document.createElement('div');
         div.classList.add('url-entry');
+        if (isDefault) {
+            div.dataset.default = 'true';
+        }
         div.innerHTML = `
             <span class="drag-handle-url">⋮</span>
             <input type="text" placeholder="http://example.com" value="${urlVal}">
@@ -204,6 +207,7 @@ document.addEventListener('DOMContentLoaded', function () {
             if (existingRadio) existingRadio.remove();
         });
         if (urlEntries.length > 1) {
+            let hasDefault = false;
             urlEntries.forEach((entry, idx) => {
                 const label = document.createElement('label');
                 label.style.cssText = "margin-left:10px; font-size:13px; color:#aaa;";
@@ -214,10 +218,17 @@ document.addEventListener('DOMContentLoaded', function () {
                 radio.name = 'defaultUrlGroup-' + container
                     .closest('.instance-group')
                     .querySelector('input[name^="instance-name"]').name;
-                if (idx === 0) radio.checked = true;
+                if (entry.dataset.default === 'true') {
+                    radio.checked = true;
+                    hasDefault = true;
+                }
                 label.appendChild(radio);
                 entry.appendChild(label);
             });
+            if (!hasDefault) {
+                const firstRadio = urlEntries[0].querySelector('input[type="radio"]');
+                if (firstRadio) firstRadio.checked = true;
+            }
         }
     }
 

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* content.css */
+/* style.css */
 /* Styles for in-page buttons like Go to Author, Publish, etc. */
 .edit-button, .switch-mode-button, .publish-button, .author-button {
     position: fixed;

--- a/tests/content.test.js
+++ b/tests/content.test.js
@@ -1,0 +1,29 @@
+const { getHostAndPort, urlsMatch } = require('../content');
+
+describe('getHostAndPort', () => {
+  test('parses hostname and port', () => {
+    expect(getHostAndPort('http://example.com:4502', '')).toEqual({ hostname: 'example.com', port: '4502' });
+  });
+
+  test('handles url without port', () => {
+    expect(getHostAndPort('http://example.com', '')).toEqual({ hostname: 'example.com', port: null });
+  });
+
+  test('invalid url returns null', () => {
+    expect(getHostAndPort('abc', '')).toBeNull();
+  });
+});
+
+describe('urlsMatch', () => {
+  test('matches same hostname and port', () => {
+    expect(urlsMatch('http://example.com', '4502', 'http://example.com:4502/foo')).toBe(true);
+  });
+
+  test('default ports are considered', () => {
+    expect(urlsMatch('https://example.com', '', 'https://example.com/foo')).toBe(true);
+  });
+
+  test('different hostnames do not match', () => {
+    expect(urlsMatch('http://example.com', '', 'http://other.com')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- update comment in `style.css`
- load default URL selection correctly in settings
- export helper functions in `content.js`
- update README instructions to say Settings page
- add Jest test suite for helper functions
- add npm package configuration and ignore node modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f3bcd0ab88329b13239c493572401